### PR TITLE
Add cstore_fdw extension by default

### DIFF
--- a/002-create-cstore-extension.sql
+++ b/002-create-cstore-extension.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION cstore_fdw;

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,16 @@ MAINTAINER Citus Data https://citusdata.com
 
 ENV CITUS_VERSION 5.1.1-1
 
-# install Citus
+# install cstore_fdw
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && apt-get install -y git gcc make postgresql-server-dev-9.5 libpq-dev python-psycopg2 \
+       protobuf-c-compiler libprotobuf-c0-dev \
+    && git clone https://github.com/citusdata/cstore_fdw /opt/cstore \
+    && cd /opt/cstore && make && make install \
+    && apt-get purge -y --auto-remove git gcc make
+
+# install Citus
+RUN apt-get install -y --no-install-recommends \
        ca-certificates \
        curl \
     && curl -s https://install.citusdata.com/community/deb.sh | bash \
@@ -13,11 +20,11 @@ RUN apt-get update \
     && apt-get purge -y --auto-remove ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 
-# add citus to default PostgreSQL config
-RUN echo "shared_preload_libraries='citus'" >> /usr/share/postgresql/postgresql.conf.sample
+# add citus with cstore_fdw to default PostgreSQL config
+RUN echo "shared_preload_libraries='citus, cstore_fdw'" >> /usr/share/postgresql/postgresql.conf.sample
 
 # add scripts to run after initdb
-COPY 000-symlink-workerlist.sh 001-create-citus-extension.sql /docker-entrypoint-initdb.d/
+COPY 000-symlink-workerlist.sh 001-create-citus-extension.sql 002-create-cstore-extension.sql /docker-entrypoint-initdb.d/
 
 # expose workerlist via volume
 VOLUME /etc/citus

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM postgres:9.5.3
+FROM postgres:9.5.5
 MAINTAINER Citus Data https://citusdata.com
 
-ENV CITUS_VERSION 5.1.1-1
+ENV CITUS_VERSION 5.2.2.citus-1
 
 # install cstore_fdw
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ The master node should be reachable at its public address on port `5432`. One la
 
 You can stop your stack with `docker-cloud stack terminate citus-cloud`.
 
+## Columnar storage
+
+Docker image contains cstore_fdw extension. You can use it from the box.
+
 ## License
 
 The following license information (and associated [LICENSE][license] file) apply _only to the files within **this** repository_. Please consult Citus’s own repository for information regarding its licensing.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ version: '2'
 services:
   master:
     container_name: 'citus_master'
-    image: 'citusdata/citus:5.1.1'
-    ports: ['5432:5432']
+    image: 'lukashes/citus-docker:5.2.2'
+    ports: ['5532:5432']
     labels: ['com.citusdata.role=Master']
   worker:
-    image: 'citusdata/citus:5.1.1'
+    image: 'lukashes/citus-docker:5.2.2'
     labels: ['com.citusdata.role=Worker']
   config:
     container_name: 'citus_config'


### PR DESCRIPTION
I don't know how you getting pull-requests (if you getting it). But it really useful have two your extensions on one box: citus + cstore_fdw. You can get my pull-request or update your Docker-file based on this pull-request.
