### PR TITLE
Set max_prepared_transactions to 200 by default to allow DDL using 2PC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN apt-get update \
 # add citus to default PostgreSQL config
 RUN echo "shared_preload_libraries='citus'" >> /usr/share/postgresql/postgresql.conf.sample
 
+# enable prepared transactions for 2PC
+RUN echo "max_prepared_transactions=200" >> /usr/share/postgresql/postgresql.conf.sample
+
 # add scripts to run after initdb
 COPY 000-symlink-workerlist.sh 001-create-citus-extension.sql /docker-entrypoint-initdb.d/
 


### PR DESCRIPTION
See $subject

I've encountered this whilst testing the DDL 2PC improvements using a Docker cluster on my local machine.
