### PR TITLE
Add developer images to easily build master or a branch for testing

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,0 +1,28 @@
+FROM citusdata/citus:latest
+MAINTAINER Citus Data https://citusdata.com
+
+ARG BRANCH=master
+
+RUN adduser --disabled-password --gecos '' citus
+
+# Install build dependencies, remove citus release package
+RUN apt-get update || true \
+    && apt-get remove -y postgresql-$PG_MAJOR-citus \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates \
+       curl \
+       postgresql-server-dev-$PG_MAJOR \
+       libedit-dev libselinux1-dev libxslt-dev  \
+       libpam0g-dev git flex make build-essential
+
+RUN mkdir /citus && chown citus /citus
+
+USER citus
+RUN git clone -b $BRANCH https://github.com/citusdata/citus.git /citus
+
+WORKDIR /citus
+RUN ./configure
+RUN make
+
+USER root
+RUN make install

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+
+services:
+  master:
+    container_name: 'citus_master'
+    image: 'citusdata/citus:dev'
+    ports: ['5432:5432']
+    labels: ['com.citusdata.role=Master']
+  worker:
+    image: 'citusdata/citus:dev'
+    labels: ['com.citusdata.role=Worker']
+  config:
+    container_name: 'citus_config'
+    image: 'citusdata/workerlist-gen:0.9.0'
+    volumes: ['/var/run/docker.sock:/tmp/docker.sock']
+    volumes_from: ['master']


### PR DESCRIPTION
This adds a Dockerfile that you can use to build a `citusdata/citus:dev` (or similarly named) image on your local machine.

Not sure if these are helpful outside my environment, but I've found it useful to run Citus inside Docker when doing testing of changes in master or of certain PRs.
