### PR TITLE
Preserve ca-certificates package in images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
        curl \
     && curl -s https://install.citusdata.com/community/deb.sh | bash \
     && apt-get install -y postgresql-$PG_MAJOR-citus=$CITUS_VERSION \
-    && apt-get purge -y --auto-remove ca-certificates curl \
+    && apt-get purge -y --auto-remove curl \
     && rm -rf /var/lib/apt/lists/*
 
 # add citus to default PostgreSQL config

--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -9,5 +9,5 @@ RUN rm -rf /etc/apt/sources.list.d/citusdata_community.list \
        curl \
     && curl -s https://install.citusdata.com/community-nightlies/deb.sh | bash \
     && apt-get install --only-upgrade -y postgresql-$PG_MAJOR-citus \
-    && apt-get purge -y --auto-remove ca-certificates curl \
+    && apt-get purge -y --auto-remove curl \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This `apt-get purge` line was copied from PostgreSQL's Dockerfile, which is fine as that image only includes apt-get sources served over HTTP.

Since the Citus package repository is served over HTTPS, purging this package results in errors, breaking `apt-get update`. That's fine for any standalone Citus use, but if users wish to build upon our images, it's a showstopper.

Simply ensuring that we don't purge the certificates package fixes all such problems.

Fixes citusdata/packaging#11