### PR TITLE
Add cstore_fdw extension to citus image

### DIFF
--- a/002-create-cstore_fdw-extension.sql
+++ b/002-create-cstore_fdw-extension.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION cstore_fdw;

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,11 @@ RUN apt-get update \
     && apt-get purge -y --auto-remove curl \
     && rm -rf /var/lib/apt/lists/*
 
-# add citus to default PostgreSQL config
-RUN echo "shared_preload_libraries='citus'" >> /usr/share/postgresql/postgresql.conf.sample
+# add citus and cstore_fdw to default PostgreSQL config
+RUN echo "shared_preload_libraries='citus,cstore_fdw'" >> /usr/share/postgresql/postgresql.conf.sample
 
 # add scripts to run after initdb
-COPY 000-symlink-workerlist.sh 001-create-citus-extension.sql /docker-entrypoint-initdb.d/
+COPY 000-symlink-workerlist.sh 001-create-citus-extension.sql 002-create-cstore_fdw-extension.sql /docker-entrypoint-initdb.d/
 
 # add our wrapper entrypoint script
 COPY citus-entrypoint.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,21 @@ MAINTAINER Citus Data https://citusdata.com
 
 ENV CITUS_VERSION 6.1.0.citus-1
 
+# build and install cstore_fdw
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates \
+       git \
+       gcc \
+       make \
+       protobuf-c-compiler \
+       libprotobuf-c0-dev \
+       libprotoc-dev \
+       postgresql-server-dev-9.6 \
+    && git clone https://github.com/citusdata/cstore_fdw /opt/cstore \
+    && cd /opt/cstore && make && make install \
+    && apt-get purge -y --auto-remove git gcc make
+
 # install Citus
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This hopefully improves over https://github.com/citusdata/docker/pull/6 and https://github.com/citusdata/docker/pull/15

I think this installs the minimal set of dependencies requeried and can be merged cleanly. If you have any comments on how to improve it I'd gladly hear them.