### PR TITLE
Add Docker flag to node metadata

### DIFF
--- a/001-create-citus-extension.sql
+++ b/001-create-citus-extension.sql
@@ -1,1 +1,7 @@
+-- wrap in transaction to ensure Docker flag always visible
+BEGIN;
 CREATE EXTENSION citus;
+
+-- add Docker flag to node metadata
+UPDATE pg_dist_node_metadata SET metadata=jsonb_insert(metadata, '{docker}', 'true');
+COMMIT;


### PR DESCRIPTION
Seems handy to have this set within Docker to identify which clusters are running in Docker.