### PR TITLE
Add name for worker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     ports: ["${MASTER_EXTERNAL_PORT:-5432}:5432"]
     labels: ['com.citusdata.role=Master']
   worker:
+    container_name: "${COMPOSE_PROJECT_NAME:-citus}_worker"
     image: 'citusdata/citus:7.0.3'
     labels: ['com.citusdata.role=Worker']
     depends_on: { manager: { condition: service_healthy } }


### PR DESCRIPTION
Currently, if runs `docker-compose up` within folder `foo`, they get the following namas:
* citus_master
* foo_worker
* citus_manager

This commit unifies the names.