### PR TITLE
Bump docker to 9.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 sudo: required
 services: [ docker ]
 script:
-  - docker build -t citusdata/citus:8.3.2 .
+  - docker build -t citusdata/citus:9.0.0 .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### citus-docker v9.0.0.docker (October 17, 2019) ###
+
+* Bump Citus version to 9.0.0
+
 ### citus-docker v8.3.2.docker (August 9, 2019) ###
 
 * Bump Citus version to 8.3.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM postgres:11.4
-ARG VERSION=8.3.2
+FROM postgres:12.0
+ARG VERSION=9.0.0
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
       org.label-schema.description="Scalable PostgreSQL for multi-tenant and real-time workloads" \
@@ -17,7 +17,7 @@ RUN apt-get update \
        ca-certificates \
        curl \
     && curl -s https://install.citusdata.com/community/deb.sh | bash \
-    && apt-get install -y postgresql-$PG_MAJOR-citus-8.3=$CITUS_VERSION \
+    && apt-get install -y postgresql-$PG_MAJOR-citus-9.0=$CITUS_VERSION \
                           postgresql-$PG_MAJOR-hll=2.12.citus-1 \
                           postgresql-$PG_MAJOR-topn=2.2.0 \
     && apt-get purge -y --auto-remove curl \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,5 +1,5 @@
-FROM postgres:11.4-alpine
-ARG VERSION=8.3.1
+FROM postgres:12.0-alpine
+ARG VERSION=9.0.0
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
       org.label-schema.description="Scalable PostgreSQL for multi-tenant and real-time workloads" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ version: '2.1'
 services:
   master:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_master"
-    image: 'citusdata/citus:8.3.2'
+    image: 'citusdata/citus:9.0.0'
     ports: ["${MASTER_EXTERNAL_PORT:-5432}:5432"]
     labels: ['com.citusdata.role=Master']
   worker:
-    image: 'citusdata/citus:8.3.2'
+    image: 'citusdata/citus:9.0.0'
     labels: ['com.citusdata.role=Worker']
     depends_on: { manager: { condition: service_healthy } }
   manager:


### PR DESCRIPTION
Blocked on https://github.com/citusdata/packaging/pull/354 as we need ubuntu 9.0 packages 

Failing because of missing HLL & TopN packages with PG12 support