### PR TITLE
Bump docker to 9.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 sudo: required
 services: [ docker ]
 script:
-  - docker build -t citusdata/citus:8.3.2 .
+  - docker build -t citusdata/citus:9.0.1 .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### citus-docker v9.0.1.docker (November 7, 2019) ###
+
+* Bump Citus version to 9.0.1
+
+### citus-docker v.0.1.docker (November 7, 2019) ###
+
+* Bump Citus version to .0.1
+
 ### citus-docker v8.3.2.docker (August 9, 2019) ###
 
 * Bump Citus version to 8.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 * Bump Citus version to 9.0.1
 
-### citus-docker v.0.1.docker (November 7, 2019) ###
-
-* Bump Citus version to .0.1
-
 ### citus-docker v8.3.2.docker (August 9, 2019) ###
 
 * Bump Citus version to 8.3.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:11.4
+FROM postgres:12.1
 ARG VERSION=9.0.1
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
@@ -18,8 +18,8 @@ RUN apt-get update \
        curl \
     && curl -s https://install.citusdata.com/community/deb.sh | bash \
     && apt-get install -y postgresql-$PG_MAJOR-citus-9.0.=$CITUS_VERSION \
-                          postgresql-$PG_MAJOR-hll=2.12.citus-1 \
-                          postgresql-$PG_MAJOR-topn=2.2.0 \
+                          postgresql-$PG_MAJOR-hll=2.14.citus-1 \
+                          postgresql-$PG_MAJOR-topn=2.3.0 \
     && apt-get purge -y --auto-remove curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM postgres:11.4
-ARG VERSION=8.3.2
+ARG VERSION=9.0.1
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
       org.label-schema.description="Scalable PostgreSQL for multi-tenant and real-time workloads" \
@@ -17,7 +17,7 @@ RUN apt-get update \
        ca-certificates \
        curl \
     && curl -s https://install.citusdata.com/community/deb.sh | bash \
-    && apt-get install -y postgresql-$PG_MAJOR-citus-8.3=$CITUS_VERSION \
+    && apt-get install -y postgresql-$PG_MAJOR-citus-9.0.=$CITUS_VERSION \
                           postgresql-$PG_MAJOR-hll=2.12.citus-1 \
                           postgresql-$PG_MAJOR-topn=2.2.0 \
     && apt-get purge -y --auto-remove curl \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,5 +1,5 @@
 FROM postgres:11.4-alpine
-ARG VERSION=8.3.1
+ARG VERSION=9.0.1
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
       org.label-schema.description="Scalable PostgreSQL for multi-tenant and real-time workloads" \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM postgres:11.4-alpine
+FROM postgres:12.1-alpine
 ARG VERSION=9.0.1
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Citus is a PostgreSQL-based distributed RDBMS. For more information, see the [Ci
 
 ## Function
 
-This image provides a single running Citus instance (atop PostgreSQL 9.6), using standard configuration values. It is based on [the official PostgreSQL image][docker-postgres], so be sure to consult that image’s documentation for advanced configuration options (including non-default settings for e.g. `PGDATA` or `POSTGRES_USER`).
+This image provides a single running Citus instance (atop PostgreSQL 12.0), using standard configuration values. It is based on [the official PostgreSQL image][docker-postgres], so be sure to consult that image’s documentation for advanced configuration options (including non-default settings for e.g. `PGDATA` or `POSTGRES_USER`).
 
 Just like the standard PostgreSQL image, this image exposes port `5432`. In other words, all containers on the same Docker network should be able to connect on this port, and exposing it externally will permit connections from external clients (`psql`, adapters, applications).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ version: '2.1'
 services:
   master:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_master"
-    image: 'citusdata/citus:8.3.2'
+    image: 'citusdata/citus:9.0.1'
     ports: ["${MASTER_EXTERNAL_PORT:-5432}:5432"]
     labels: ['com.citusdata.role=Master']
   worker:
-    image: 'citusdata/citus:8.3.2'
+    image: 'citusdata/citus:9.0.1'
     labels: ['com.citusdata.role=Worker']
     depends_on: { manager: { condition: service_healthy } }
   manager:


### PR DESCRIPTION
We need to update `https://install.citusdata.com/community/deb.sh` before we can install out packagecloud repository in the latest Debian 10 Buster image.

Blocked on https://github.com/citusdata/packaging/pull/358