### PR TITLE
Add Alpine build to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: required
 services: [ docker ]
+env:
+  - DOCKERFILE=Dockerfile
+  - DOCKERFILE=Dockerfile-alpine
 script:
-  - docker build -t citusdata/citus:9.1.0 .
+  - docker build -f "$DOCKERFILE" -t citusdata/citus:9.1.0 .


### PR DESCRIPTION
Travis builds only the Debian image, and we can't see if there is a problem with Alpine image in the CI. This PR makes Travis build both images.  