### PR TITLE
Bump membership-manager

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,6 @@ services:
     depends_on: { manager: { condition: service_healthy } }
   manager:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_manager"
-    image: 'citusdata/membership-manager:0.2.0'
+    image: 'citusdata/membership-manager:0.2.1'
     volumes: ['/var/run/docker.sock:/var/run/docker.sock']
     depends_on: { master: { condition: service_healthy } }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ version: '2.1'
 services:
   master:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_master"
-    image: 'citusdata/citus:9.2.2-1'
+    image: 'citusdata/citus:9.2.2'
     ports: ["${MASTER_EXTERNAL_PORT:-5432}:5432"]
     labels: ['com.citusdata.role=Master']
   worker:
-    image: 'citusdata/citus:9.2.2-1'
+    image: 'citusdata/citus:9.2.2'
     labels: ['com.citusdata.role=Worker']
     depends_on: { manager: { condition: service_healthy } }
   manager:


### PR DESCRIPTION
We recently created a tag `v.0.2.1` for [membership-manager](https://github.com/citusdata/membership-manager)

This PR bumps the version, and removes the fancy versioning that is not really necessary