### PR TITLE
Support postgres:12.2 docker and allow passwords in docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12.1
+FROM postgres:12.2
 ARG VERSION=9.2.3
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
@@ -31,5 +31,9 @@ COPY 000-configure-stats.sh 001-create-citus-extension.sql /docker-entrypoint-in
 
 # add health check script
 COPY pg_healthcheck /
+
+# entry point unsets PGPASSWORD, but we need it to connect to workers
+# https://github.com/docker-library/postgres/blob/33bccfcaddd0679f55ee1028c012d26cd196537d/12/docker-entrypoint.sh#L303
+RUN sed "/unset PGPASSWORD/d" -i /usr/local/bin/docker-entrypoint.sh
 
 HEALTHCHECK --interval=4s --start-period=6s CMD ./pg_healthcheck

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM postgres:12.1-alpine
+FROM postgres:12.2-alpine
 ARG VERSION=9.2.3
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,20 @@ services:
     image: 'citusdata/citus:9.2.3'
     ports: ["${MASTER_EXTERNAL_PORT:-5432}:5432"]
     labels: ['com.citusdata.role=Master']
+    environment: &AUTH
+      POSTGRES_USER: "${POSTGRES_USER:-postgres}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      PGUSER: "${POSTGRES_USER:-postgres}"
+      PGPASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_HOST_AUTH_METHOD: "${POSTGRES_HOST_AUTH_METHOD:-trust}"
   worker:
     image: 'citusdata/citus:9.2.3'
     labels: ['com.citusdata.role=Worker']
     depends_on: { manager: { condition: service_healthy } }
+    environment: *AUTH
   manager:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_manager"
     image: 'citusdata/membership-manager:0.2.1'
     volumes: ['/var/run/docker.sock:/var/run/docker.sock']
     depends_on: { master: { condition: service_healthy } }
+    environment: *AUTH

--- a/nightly/docker-compose.yml
+++ b/nightly/docker-compose.yml
@@ -6,12 +6,20 @@ services:
     image: 'citusdata/citus:nightly'
     ports: ["${MASTER_EXTERNAL_PORT:-5432}:5432"]
     labels: ['com.citusdata.role=Master']
+    environment: &AUTH
+      POSTGRES_USER: "${POSTGRES_USER:-postgres}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      PGUSER: "${POSTGRES_USER:-postgres}"
+      PGPASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_HOST_AUTH_METHOD: "${POSTGRES_HOST_AUTH_METHOD:-trust}"
   worker:
     image: 'citusdata/citus:nightly'
     labels: ['com.citusdata.role=Worker']
     depends_on: { manager: { condition: service_healthy } }
+    environment: *AUTH
   manager:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_manager"
     image: 'citusdata/membership-manager:0.2.1'
     volumes: ['/var/run/docker.sock:/var/run/docker.sock']
     depends_on: { master: { condition: service_healthy } }
+    environment: *AUTH


### PR DESCRIPTION
This is partially based on https://github.com/citusdata/docker/issues/75

Passwords can now be used by doing:
```bash
export POSTGRES_PASSWORD=abc
export POSTGRES_HOST_AUTH_METHOD=md5
docker-compose -p citus up
```

Closes #75 