### PR TITLE
Downgrade Citus to 9.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ env:
   - DOCKERFILE=Dockerfile
   - DOCKERFILE=Dockerfile-alpine
 script:
-  - docker build -f "$DOCKERFILE" -t citusdata/citus:9.2.3 .
+  - docker build -f "$DOCKERFILE" -t citusdata/citus:9.2.2 .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### citus-docker v9.2.2-2.docker (March 30, 2020) ###
+
+* Downgrade Citus version to 9.2.2
+
 ### citus-docker v9.2.3.docker (March 26, 2020) ###
 
 * Bump Citus version to 9.2.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM postgres:12.2
-ARG VERSION=9.2.3
+ARG VERSION=9.2.2
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
       org.label-schema.description="Scalable PostgreSQL for multi-tenant and real-time workloads" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12.1
+FROM postgres:12.2
 ARG VERSION=9.2.3
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
@@ -31,5 +31,9 @@ COPY 000-configure-stats.sh 001-create-citus-extension.sql /docker-entrypoint-in
 
 # add health check script
 COPY pg_healthcheck /
+
+# entry point unsets PGPASSWORD, but we need it to connect to workers
+# https://github.com/docker-library/postgres/blob/33bccfcaddd0679f55ee1028c012d26cd196537d/12/docker-entrypoint.sh#L303
+RUN sed "/unset PGPASSWORD/d" -i /usr/local/bin/docker-entrypoint.sh
 
 HEALTHCHECK --interval=4s --start-period=6s CMD ./pg_healthcheck

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -38,4 +38,8 @@ COPY 000-configure-stats.sh 001-create-citus-extension.sql /docker-entrypoint-in
 # add health check script
 COPY pg_healthcheck /
 
+# entry point unsets PGPASSWORD, but we need it to connect to workers
+# https://github.com/docker-library/postgres/blob/33bccfcaddd0679f55ee1028c012d26cd196537d/12/docker-entrypoint.sh#L303
+RUN sed "/unset PGPASSWORD/d" -i /usr/local/bin/docker-entrypoint.sh
+
 HEALTHCHECK --interval=4s --start-period=6s CMD ./pg_healthcheck

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,5 +1,5 @@
 FROM postgres:12.2-alpine
-ARG VERSION=9.2.3
+ARG VERSION=9.2.2
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
       org.label-schema.description="Scalable PostgreSQL for multi-tenant and real-time workloads" \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM postgres:12.1-alpine
+FROM postgres:12.2-alpine
 ARG VERSION=9.2.3
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Citus is a PostgreSQL-based distributed RDBMS. For more information, see the [Ci
 
 ## Function
 
-This image provides a single running Citus instance (atop PostgreSQL 12.0), using standard configuration values. It is based on [the official PostgreSQL image][docker-postgres], so be sure to consult that image’s documentation for advanced configuration options (including non-default settings for e.g. `PGDATA` or `POSTGRES_USER`).
+This image provides a single running Citus instance (atop PostgreSQL 12.2), using standard configuration values. It is based on [the official PostgreSQL image][docker-postgres], so be sure to consult that image’s documentation for advanced configuration options (including non-default settings for e.g. `PGDATA` or `POSTGRES_USER`).
 
 Just like the standard PostgreSQL image, this image exposes port `5432`. In other words, all containers on the same Docker network should be able to connect on this port, and exposing it externally will permit connections from external clients (`psql`, adapters, applications).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,20 @@ services:
     image: 'citusdata/citus:9.2.3'
     ports: ["${MASTER_EXTERNAL_PORT:-5432}:5432"]
     labels: ['com.citusdata.role=Master']
+    environment: &AUTH
+      POSTGRES_USER: "${POSTGRES_USER:-postgres}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      PGUSER: "${POSTGRES_USER:-postgres}"
+      PGPASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_HOST_AUTH_METHOD: "${POSTGRES_HOST_AUTH_METHOD:-trust}"
   worker:
     image: 'citusdata/citus:9.2.3'
     labels: ['com.citusdata.role=Worker']
     depends_on: { manager: { condition: service_healthy } }
+    environment: *AUTH
   manager:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_manager"
     image: 'citusdata/membership-manager:0.2.1'
     volumes: ['/var/run/docker.sock:/var/run/docker.sock']
     depends_on: { master: { condition: service_healthy } }
+    environment: *AUTH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2.1'
 services:
   master:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_master"
-    image: 'citusdata/citus:9.2.3'
+    image: 'citusdata/citus:9.2.2'
     ports: ["${MASTER_EXTERNAL_PORT:-5432}:5432"]
     labels: ['com.citusdata.role=Master']
     environment: &AUTH
@@ -13,7 +13,7 @@ services:
       PGPASSWORD: "${POSTGRES_PASSWORD}"
       POSTGRES_HOST_AUTH_METHOD: "${POSTGRES_HOST_AUTH_METHOD:-trust}"
   worker:
-    image: 'citusdata/citus:9.2.3'
+    image: 'citusdata/citus:9.2.2'
     labels: ['com.citusdata.role=Worker']
     depends_on: { manager: { condition: service_healthy } }
     environment: *AUTH

--- a/nightly/docker-compose.yml
+++ b/nightly/docker-compose.yml
@@ -6,12 +6,20 @@ services:
     image: 'citusdata/citus:nightly'
     ports: ["${MASTER_EXTERNAL_PORT:-5432}:5432"]
     labels: ['com.citusdata.role=Master']
+    environment: &AUTH
+      POSTGRES_USER: "${POSTGRES_USER:-postgres}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      PGUSER: "${POSTGRES_USER:-postgres}"
+      PGPASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_HOST_AUTH_METHOD: "${POSTGRES_HOST_AUTH_METHOD:-trust}"
   worker:
     image: 'citusdata/citus:nightly'
     labels: ['com.citusdata.role=Worker']
     depends_on: { manager: { condition: service_healthy } }
+    environment: *AUTH
   manager:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_manager"
     image: 'citusdata/membership-manager:0.2.1'
     volumes: ['/var/run/docker.sock:/var/run/docker.sock']
     depends_on: { master: { condition: service_healthy } }
+    environment: *AUTH


### PR DESCRIPTION
We have some issues with Citus `9.2.3` release, so downgrading the version to `9.2.2` instead.

Apparently we merged #178 and #179 into master, instead of develop and thus they diverged. Cherry-picked the missing commits here as well.

After this PR is merged into develop, I'll merge develop into master and it will be fixed 