### PR TITLE
Introduce DockerHub build trigger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ services: [ docker ]
 stages:
   - build-image
   - name: trigger-dockerhub
-    if: branch = master
+    if: branch = master AND type != pull_request
 env:
   global:
     secure: ltHu30nhJVVl5QhdBk1jaf45V6TO9S+JhxAqVgDAxItyJu3PzoNWa2M9ocxP2axONHfEFhekjGrch09SYjChmr5lwPr/58vQHc1RR8plRR77mIrySGDIF3L0fxHmecCcx3uzEQhYmrEMoToo3WVAViNVYB2R3i/8Kp4pgKQUZza+C5RgLaymHntaebyuW3PSKi3ReDjQdU6KH/Xv2p9jBtVs7XCjSPs7BYvvm8miHlo2GwynB+iIpqksvrBG3C7A9FSaOSaggyx6d3eKQKPNUbj8bakDJuuGgAVs1RHSRyjS6MzvdFgLgvr8/Mve4X840Dt5YfI9pAIIm37KY+/ZduisGUrqIPsD0agJ8BZjmDMFLdAfbY3G2vcoRS+7UnJoSSVDxqtPFbsdqKKz2n4a3XbZHPNmGAZeunncfXz/332hlj9qapYKP+PN3ZS3aCpJgG2V8+uyhfboDKCfQk3/TKhoNDg/BrNZdLTSZT8HCmExerG98l2OFcjX/4Zi/Q6fGBf7TbERCGdBpYqx4CWSPO2OpQ7IP0mLOWWNiVeHzhj0w1ELmJPgFWNdROxGIdjN/YyMyjrXe/NF9zvqbUcH4X419W69vLyFB7+hdXkGYJ4E8BiG7Kc7O7JOugMgzQ6kJ+7AtmaQDZnq1ZUACQ5BTS+68PUqKRZYCdcXqxi7Y0M=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,23 @@
-sudo: required
 services: [ docker ]
+stages:
+  - build-image
+  - name: trigger-dockerhub
+    if: branch = master
 env:
-  - DOCKERFILE=Dockerfile
-  - DOCKERFILE=Dockerfile-alpine
+  global:
+    secure: ltHu30nhJVVl5QhdBk1jaf45V6TO9S+JhxAqVgDAxItyJu3PzoNWa2M9ocxP2axONHfEFhekjGrch09SYjChmr5lwPr/58vQHc1RR8plRR77mIrySGDIF3L0fxHmecCcx3uzEQhYmrEMoToo3WVAViNVYB2R3i/8Kp4pgKQUZza+C5RgLaymHntaebyuW3PSKi3ReDjQdU6KH/Xv2p9jBtVs7XCjSPs7BYvvm8miHlo2GwynB+iIpqksvrBG3C7A9FSaOSaggyx6d3eKQKPNUbj8bakDJuuGgAVs1RHSRyjS6MzvdFgLgvr8/Mve4X840Dt5YfI9pAIIm37KY+/ZduisGUrqIPsD0agJ8BZjmDMFLdAfbY3G2vcoRS+7UnJoSSVDxqtPFbsdqKKz2n4a3XbZHPNmGAZeunncfXz/332hlj9qapYKP+PN3ZS3aCpJgG2V8+uyhfboDKCfQk3/TKhoNDg/BrNZdLTSZT8HCmExerG98l2OFcjX/4Zi/Q6fGBf7TbERCGdBpYqx4CWSPO2OpQ7IP0mLOWWNiVeHzhj0w1ELmJPgFWNdROxGIdjN/YyMyjrXe/NF9zvqbUcH4X419W69vLyFB7+hdXkGYJ4E8BiG7Kc7O7JOugMgzQ6kJ+7AtmaQDZnq1ZUACQ5BTS+68PUqKRZYCdcXqxi7Y0M=
 script:
-  - docker build -f "$DOCKERFILE" -t citusdata/citus:9.2.4 .
+jobs:
+  include:
+    - stage: build-image
+      name: "latest"
+      script: docker build -f Dockerfile .
+    - stage: build-image
+      name: "alpine"
+      script: docker build -f Dockerfile-alpine .
+    - stage: build-image
+      name: "nightly"
+      script: docker build -f nightly/Dockerfile .
+    - stage: trigger-dockerhub
+      name: "Trigger DockerHub Builds"
+      script: curl -X POST "$DOCKERHUB_BUILD_TRIGGER"


### PR DESCRIPTION
We have several rules on Docker Hub that gets triggered on branch and tag pushes. However we do not have a mechanism to update images nightly. This PR aims to do the following:

- Introduce nightly image creation in test steps
- Provide clear and understandable names that help improve CI interface
- Create a mechanism to update the docker images every day

Proposed CI workflow:
- Run 3 jobs in parallel, create `latest`, `alpine` and `nightly` images
- Trigger Docker Hub builds only when:
	- on master branch
	- all the images were successfully built