### PR TITLE
Implement service dependencies for Docker-Compose V3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### citus-docker v9.2.4-2.docker (March 31, 2020) ###
+
+* Add Docker Compose V3 support
+
 ### citus-docker v9.2.4.docker (March 31, 2020) ###
 
 * Bump Citus version to 9.2.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN echo "shared_preload_libraries='citus'" >> /usr/share/postgresql/postgresql.
 COPY 000-configure-stats.sh 001-create-citus-extension.sql /docker-entrypoint-initdb.d/
 
 # add health check script
-COPY pg_healthcheck /
+COPY pg_healthcheck wait-for-manager.sh /
+RUN chmod +x /wait-for-manager.sh
 
 # entry point unsets PGPASSWORD, but we need it to connect to workers
 # https://github.com/docker-library/postgres/blob/33bccfcaddd0679f55ee1028c012d26cd196537d/12/docker-entrypoint.sh#L303

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '3'
 
 services:
   master:
@@ -15,11 +15,18 @@ services:
   worker:
     image: 'citusdata/citus:9.2.4'
     labels: ['com.citusdata.role=Worker']
-    depends_on: { manager: { condition: service_healthy } }
+    depends_on: [ manager ]
     environment: *AUTH
+    command: "/wait-for-manager.sh"
+    volumes: 
+      - healthcheck-volume:/healthcheck
   manager:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_manager"
-    image: 'citusdata/membership-manager:0.2.1'
-    volumes: ['/var/run/docker.sock:/var/run/docker.sock']
-    depends_on: { master: { condition: service_healthy } }
+    image: 'citusdata/membership-manager:0.3.0'
+    volumes: 
+      - /var/run/docker.sock:/var/run/docker.sock
+      - healthcheck-volume:/healthcheck
+    depends_on: [ master ]
     environment: *AUTH
+volumes:
+  healthcheck-volume:

--- a/nightly/docker-compose.yml
+++ b/nightly/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     environment: *AUTH
   manager:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_manager"
-    image: 'citusdata/membership-manager:0.2.1'
+    image: 'citusdata/membership-manager:latest'
     volumes: ['/var/run/docker.sock:/var/run/docker.sock']
     depends_on: { master: { condition: service_healthy } }
     environment: *AUTH

--- a/wait-for-manager.sh
+++ b/wait-for-manager.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# wait-for-manager.sh
+
+set -e
+
+until test -f /healthcheck/manager-ready ; do
+  >&2 echo "Manager is not ready - sleeping"
+  sleep 1
+done
+
+>&2 echo "Manager is up - starting worker"
+
+exec gosu postgres "/docker-entrypoint.sh" "postgres"


### PR DESCRIPTION
Docker Version 3 has some changes in service dependency definitions. We designed Citus `docker-compose.yml` in a way that the services should be run in the order below:
1. Citus Coordinator service
2. Membership-manager
3. Citus Worker services

Docker Compose Version 3 no longer supports [`depends_on`](https://docs.docker.com/compose/compose-file/#depends_on) statements.

[Docker startup order docs](https://docs.docker.com/compose/startup-order/) also state that:
> ... for startup Compose does not wait until a container is “ready” (whatever that means for your particular application) - only until it’s running. There’s a good reason for this.

This means that the worker services should be able to understand if the `membership-manager` is ready, and this will be done via the existence of the file `/healthcheck/manager-ready` that will reside in a volume `/healthcheck` that is also attached to the worker nodes as well as the Membership Manager.

Blocked on: https://github.com/citusdata/membership-manager/pull/9