### PR TITLE
Fixes for Update docker files pipeline integration

### DIFF
--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -30,7 +30,7 @@ jobs:
         run: sudo apt install libcurl4-openssl-dev libssl-dev
 
       - name: Clone tools branch
-        run: git clone -b issue_147 --depth=1  https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.1 --depth=1  https://github.com/citusdata/tools.git tools
 
       - name: Set git name and email
         run: |

--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -1,15 +1,26 @@
 name: Update Version on Docker Files
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  POSTGRES_VERSION: ${{ github.event.inputs.postgres_version }}
 on:
- workflow_dispatch:
+  workflow_dispatch:
     inputs:
       project_version:
-        description: 'Version number to be released e.g 10.0.3'
+        description: "Version number to be released e.g 10.0.3"
       postgres_version:
         required: false
-        description: 'Postgres version number. If it is empty, postgres version will not be changed'
+        description: "Postgres version number. If it is empty, postgres version will not be changed"
+      microsoft_email:
+        description: "Email to be written on changelogs"
+        default: "gindibay@microsoft.com"
+      name:
+        description: "Name to be written on changelogs"
+        default: "Gurkan Indibay"
 
 jobs:
-  build:
+  update_docker_files:
+    name: "Update docker files"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -19,14 +30,21 @@ jobs:
         run: sudo apt install libcurl4-openssl-dev libssl-dev
 
       - name: Clone tools branch
-        run: git clone -b v0.8.0 --depth=1  https://github.com/citusdata/tools.git tools
-        
+        run: git clone -b issue_147 --depth=1  https://github.com/citusdata/tools.git tools
+
+      - name: Set git name and email
+        run: |
+          git config --global user.email "${{ github.event.inputs.microsoft_email }}" && \
+          git config --global user.name "${{ github.event.inputs.name }}"
+
       - name: Install python requirements
         run: export PYTHONPATH="$(pwd)/tools" && python -m pip install -r tools/packaging_automation/requirements.txt
-        
+
       - name: Update docker files
         run: |
           python -m tools.packaging_automation.update_docker \
           --prj_ver ${{ github.event.inputs.project_version }} \
-          --gh-token ${{ secrets.GH_TOKEN }} \
-          --postgres_version ${{ github.event.inputs.postgres_version }}
+          --gh_token "${GH_TOKEN}" \
+          --pipeline \
+          --exec_path "$(pwd)" \
+          --postgres_version "${POSTGRES_VERSION}"


### PR DESCRIPTION
There were some problems while executing "Update version on Docker files"
Problems fixed are as below
1. pipeline flag is added in update_docker script (tools issue 147). This flag is integrated into this pipeline
2. update_docker script needs git email and name configuration. This was added as step
3. environment parameters were used instead of input parameters in python command to remove the secret leakage risk (GH_TOKEN) and to be able to handle null parameters ( POSTGRES_VERSION) 

Before merging this PR , tools PR 148 should be merged. After merging PR 148, I will change 
```
git clone -b issue_147 --depth=1 https://github.com/citusdata/tools.git tools into 
```
into
```
git clone -b develop --depth=1 https://github.com/citusdata/tools.git tools into 
```

