### PR TITLE
Adds additional git parameter into tag pipeline to fix creating tagged docker images with git tag

### DIFF
--- a/.github/workflows/publish_docker_images_on_push.yml
+++ b/.github/workflows/publish_docker_images_on_push.yml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: master
 
       - name: Clone tools branch
         run: git clone -b v0.8.8 --depth=1 https://github.com/citusdata/tools.git tools


### PR DESCRIPTION
While tagging, Github Actions checks out partially which prevents tag check. In our tagging script to make sure that there is a tag to create docker images with intended tags, we check whether the given tag exists on the master branch. Without fetch-depth and ref:master parameters this check always returns false. With this fix, now checks returns successfully