### PR TITLE
Bump docker to version 11.0.0_beta

### DIFF
--- a/.github/workflows/publish_docker_images_cron.yml
+++ b/.github/workflows/publish_docker_images_cron.yml
@@ -19,7 +19,6 @@ jobs:
         image_type:
           - latest
           - alpine
-          - postgres_12
           - postgres_13
           - nightly
     steps:

--- a/.github/workflows/publish_docker_images_on_push.yml
+++ b/.github/workflows/publish_docker_images_on_push.yml
@@ -17,7 +17,6 @@ jobs:
         image_type:
           - latest
           - alpine
-          - postgres_12
           - postgres_13
           - nightly
     steps:

--- a/.github/workflows/publish_docker_images_on_tag.yml
+++ b/.github/workflows/publish_docker_images_on_tag.yml
@@ -17,7 +17,6 @@ jobs:
         image_type:
           - latest
           - alpine
-          - postgres_12
           - postgres_13
           - nightly
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 * Bump Citus version to 11.0.0_beta
 
-* Bump PostgreSQL version to 14.2
-
 ### citus-docker v10.2.5.docker (March 17,2022) ###
 
 * Bump Citus version to 10.2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### citus-docker v11.0.0_beta.docker (March 24,2022) ###
+
+* Bump Citus version to 11.0.0_beta
+
+* Bump PostgreSQL version to 14.2
+
 ### citus-docker v10.2.5.docker (March 17,2022) ###
 
 * Bump Citus version to 10.2.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This file is auto generated from it's template,
 # see citusdata/tools/packaging_automation/templates/docker/latest/latest.tmpl.dockerfile.
 FROM postgres:14.2
-ARG VERSION=10.2.5
+ARG VERSION=11.0.0-beta
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
       org.label-schema.description="Scalable PostgreSQL for multi-tenant and real-time workloads" \
@@ -19,7 +19,7 @@ RUN apt-get update \
        ca-certificates \
        curl \
     && curl -s https://install.citusdata.com/community/deb.sh | bash \
-    && apt-get install -y postgresql-$PG_MAJOR-citus-10.2=$CITUS_VERSION \
+    && apt-get install -y postgresql-$PG_MAJOR-citus-beta-11.0=$CITUS_VERSION \
                           postgresql-$PG_MAJOR-hll=2.16.citus-1 \
                           postgresql-$PG_MAJOR-topn=2.4.0 \
     && apt-get purge -y --auto-remove curl \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,7 +1,7 @@
 # This file is auto generated from it's template,
 # see citusdata/tools/packaging_automation/templates/docker/alpine/alpine.tmpl.dockerfile.
 FROM postgres:14.2-alpine
-ARG VERSION=10.2.5
+ARG VERSION=11.0.0_beta
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
       org.label-schema.description="Scalable PostgreSQL for multi-tenant and real-time workloads" \
@@ -15,8 +15,8 @@ LABEL maintainer="Citus Data https://citusdata.com" \
 RUN apk add --no-cache \
             --virtual builddeps \
         build-base \
-        curl \
         krb5-dev \
+        curl \
         curl-dev \
         openssl-dev \
         ca-certificates \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ version: "3"
 services:
   master:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_master"
-    image: "citusdata/citus:10.2.5"
+    image: "citusdata/citus:11.0.0_beta"
     ports: ["${COORDINATOR_EXTERNAL_PORT:-5432}:5432"]
     labels: ["com.citusdata.role=Master"]
     environment: &AUTH
@@ -15,7 +15,7 @@ services:
       PGPASSWORD: "${POSTGRES_PASSWORD}"
       POSTGRES_HOST_AUTH_METHOD: "${POSTGRES_HOST_AUTH_METHOD:-trust}"
   worker:
-    image: "citusdata/citus:10.2.5"
+    image: "citusdata/citus:11.0.0_beta"
     labels: ["com.citusdata.role=Worker"]
     depends_on: [manager]
     environment: *AUTH

--- a/postgres-12/Dockerfile
+++ b/postgres-12/Dockerfile
@@ -1,7 +1,7 @@
 # This file is auto generated from it's template,
 # see citusdata/tools/packaging_automation/templates/docker/postgres-12/postgres-12.tmpl.dockerfile.
 FROM postgres:12.10
-ARG VERSION=10.2.5
+ARG VERSION=11.0.0-beta
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
       org.label-schema.description="Scalable PostgreSQL for multi-tenant and real-time workloads" \
@@ -19,7 +19,7 @@ RUN apt-get update \
        ca-certificates \
        curl \
     && curl -s https://install.citusdata.com/community/deb.sh | bash \
-    && apt-get install -y postgresql-$PG_MAJOR-citus-10.2=$CITUS_VERSION \
+    && apt-get install -y postgresql-$PG_MAJOR-citus-beta-11.0=$CITUS_VERSION \
                           postgresql-$PG_MAJOR-hll=2.16.citus-1 \
                           postgresql-$PG_MAJOR-topn=2.4.0 \
     && apt-get purge -y --auto-remove curl \

--- a/postgres-13/Dockerfile
+++ b/postgres-13/Dockerfile
@@ -1,7 +1,7 @@
 # This file is auto generated from it's template,
 # see citusdata/tools/packaging_automation/templates/docker/postgres-13/postgres-13.tmpl.dockerfile.
 FROM postgres:13.6
-ARG VERSION=10.2.5
+ARG VERSION=11.0.0-beta
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
       org.label-schema.description="Scalable PostgreSQL for multi-tenant and real-time workloads" \
@@ -19,7 +19,7 @@ RUN apt-get update \
        ca-certificates \
        curl \
     && curl -s https://install.citusdata.com/community/deb.sh | bash \
-    && apt-get install -y postgresql-$PG_MAJOR-citus-10.2=$CITUS_VERSION \
+    && apt-get install -y postgresql-$PG_MAJOR-citus-beta-11.0=$CITUS_VERSION \
                           postgresql-$PG_MAJOR-hll=2.16.citus-1 \
                           postgresql-$PG_MAJOR-topn=2.4.0 \
     && apt-get purge -y --auto-remove curl \


### PR DESCRIPTION
Since pg 12 packages are missing for 11.0.x , pg 12 task is failing. Could we accept that failure and open an issue and externalize postgres multiplication in another task? 