### PR TITLE
docker-compose scale is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ SELECT master_get_active_worker_nodes();
 But you can add more workers at will using `docker-compose scale` in another tab. For instance, to bring your worker count to five…
 
 ```bash
-docker-compose -p citus scale worker=5
+docker-compose -p citus up --scale worker=5
 
 # Creating and starting 2 ... done
 # Creating and starting 3 ... done


### PR DESCRIPTION
This command is deprecated. Use the up command with the --scale flag instead. Beware that using up with the --scale flag has some subtle differences with the scale command, as it incorporates the behaviour of the up command.

Ref.: https://docs.docker.com/compose/reference/scale/