### PR TITLE
Adds hadolint Dockerfile linter

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      pull-requests: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Hadolint is a dockerfile checker. I added it to be able to validate Dockerfiles
More details: https://hub.docker.com/r/hadolint/hadolint