### PR TITLE
Allow passing extra arguments to wait-for-manager

### DIFF
--- a/wait-for-manager.sh
+++ b/wait-for-manager.sh
@@ -10,4 +10,4 @@ done
 
 >&2 echo "Manager is up - starting worker"
 
-exec gosu postgres "/usr/local/bin/docker-entrypoint.sh" "postgres"
+exec gosu postgres "/usr/local/bin/docker-entrypoint.sh" "postgres" "$@"


### PR DESCRIPTION
Allows to use
```yaml
worker:
  command: ["/wait-for-manager.sh", "-c", "wal_level=logical"]
```
to allow shard movements like
```sql
select citus_move_shard_placement(102024, 'citus-worker-2', 5432, 'citus-worker-1', 5432);
```