### PR TITLE
Fixes source build of citus for alpine

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -20,8 +20,9 @@ RUN apk add --no-cache \
         curl-dev \
         openssl-dev \
         ca-certificates \
-        clang \
         llvm \
+        llvm15-dev \
+        clang15 \
         lz4-dev \
         zstd-dev \
         libxslt-dev \


### PR DESCRIPTION
For postgres 15.3 build failed.
Added clang15 and llvm15-dev to fix the issue
Reference:
https://github.com/docker-library/postgres/commit/a3b0bb68faed03c6edd3978b8dd34ca67881f7c7#diff-263e4d92e2bddc6bbd3c9031218d17dfb38bd68d9e94f05d0604c41207944d98R47