### PR TITLE
Bump docker to version 14.1.0 (PostgreSQL 18.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### citus-docker v14.1.0.docker (June 22,2026) ###
+
+* Bump Citus version to 14.1.0
+* Bump PostgreSQL 18 base image to 18.4
+* Bump alpine build toolchain to clang21/llvm21 to match the 18.4-alpine base
+
 ### citus-docker v14.0.0.docker (February 11,2026) ###
 
 * Bump Citus version to 14.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This file is auto generated from it's template,
 # see citusdata/tools/packaging_automation/templates/docker/latest/latest.tmpl.dockerfile.
-FROM postgres:18.1
-ARG VERSION=14.0.0
+FROM postgres:18.4
+ARG VERSION=14.1.0
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
       org.label-schema.description="Scalable PostgreSQL for multi-tenant and real-time workloads" \
@@ -20,7 +20,7 @@ RUN apt-get update \
          ca-certificates=* \
          curl=* \
     && curl -s https://install.citusdata.com/community/deb.sh | bash \
-    && apt-get install -y --no-install-recommends "postgresql-$PG_MAJOR-citus-14.0=$CITUS_VERSION" \
+    && apt-get install -y --no-install-recommends "postgresql-$PG_MAJOR-citus-14.1=$CITUS_VERSION" \
                                   "postgresql-$PG_MAJOR-hll=2.19.citus-1" \
                                   "postgresql-$PG_MAJOR-topn=2.7.0.citus-1" \
     && apt-get purge -y --auto-remove curl \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,7 +1,7 @@
 # This file is auto generated from it's template,
 # see citusdata/tools/packaging_automation/templates/docker/alpine/alpine.tmpl.dockerfile.
-FROM postgres:18.1-alpine
-ARG VERSION=14.0.0
+FROM postgres:18.4-alpine
+ARG VERSION=14.1.0
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
       org.label-schema.description="Scalable PostgreSQL for multi-tenant and real-time workloads" \
@@ -20,8 +20,8 @@ RUN apk add --no-cache \
         curl-dev \
         openssl-dev \
         ca-certificates \
-        clang19 \
-        llvm19 \
+        clang21 \
+        llvm21 \
         lz4-dev \
         zstd-dev \
         libxslt-dev \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ version: "3"
 services:
   master:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_master"
-    image: "citusdata/citus:14.0.0"
+    image: "citusdata/citus:14.1.0"
     ports: ["${COORDINATOR_EXTERNAL_PORT:-5432}:5432"]
     labels: ["com.citusdata.role=Master"]
     environment: &AUTH
@@ -15,7 +15,7 @@ services:
       PGPASSWORD: "${POSTGRES_PASSWORD}"
       POSTGRES_HOST_AUTH_METHOD: "${POSTGRES_HOST_AUTH_METHOD:-trust}"
   worker:
-    image: "citusdata/citus:14.0.0"
+    image: "citusdata/citus:14.1.0"
     labels: ["com.citusdata.role=Worker"]
     depends_on: [manager]
     environment: *AUTH

--- a/pkgvars
+++ b/pkgvars
@@ -1,4 +1,4 @@
-postgres_18_version=18.1
+postgres_18_version=18.4
 postgres_17_version=17.6
 postgres_16_version=16.10
 

--- a/postgres-16/Dockerfile
+++ b/postgres-16/Dockerfile
@@ -1,7 +1,7 @@
 # This file is auto generated from it's template,
 # see citusdata/tools/packaging_automation/templates/docker/postgres-16/postgres-16.tmpl.dockerfile.
 FROM postgres:16.10
-ARG VERSION=14.0.0
+ARG VERSION=14.1.0
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
       org.label-schema.description="Scalable PostgreSQL for multi-tenant and real-time workloads" \
@@ -19,7 +19,7 @@ RUN apt-get update \
        ca-certificates \
        curl \
     && curl -s https://install.citusdata.com/community/deb.sh | bash \
-    && apt-get install -y postgresql-$PG_MAJOR-citus-14.0=$CITUS_VERSION \
+    && apt-get install -y postgresql-$PG_MAJOR-citus-14.1=$CITUS_VERSION \
                           postgresql-$PG_MAJOR-hll=2.19.citus-1 \
                           postgresql-$PG_MAJOR-topn=2.7.0.citus-1 \
     && apt-get purge -y --auto-remove curl \

--- a/postgres-17/Dockerfile
+++ b/postgres-17/Dockerfile
@@ -1,7 +1,7 @@
 # This file is auto generated from it's template,
 # see citusdata/tools/packaging_automation/templates/docker/postgres-17/postgres-17.tmpl.dockerfile.
 FROM postgres:17.6
-ARG VERSION=14.0.0
+ARG VERSION=14.1.0
 LABEL maintainer="Citus Data https://citusdata.com" \
       org.label-schema.name="Citus" \
       org.label-schema.description="Scalable PostgreSQL for multi-tenant and real-time workloads" \
@@ -19,7 +19,7 @@ RUN apt-get update \
        ca-certificates \
        curl \
     && curl -s https://install.citusdata.com/community/deb.sh | bash \
-    && apt-get install -y postgresql-$PG_MAJOR-citus-14.0=$CITUS_VERSION \
+    && apt-get install -y postgresql-$PG_MAJOR-citus-14.1=$CITUS_VERSION \
                           postgresql-$PG_MAJOR-hll=2.19.citus-1 \
                           postgresql-$PG_MAJOR-topn=2.7.0.citus-1 \
     && apt-get purge -y --auto-remove curl \


### PR DESCRIPTION
## What

Cuts the **Citus 14.1.0** Docker release. The apt/yum community packages for Citus 14.1 on PostgreSQL 18 already exist and work, but no corresponding Docker image was ever published (the latest published tags are `14`/`14.0`/`14.0.0`). The citusdata.com download page references `citusdata/citus:14.1`, which is currently a broken `docker run`. This bump + the `v14.1.0` tag triggers `publish_docker_images_on_tag.yml` to build and publish `14.1` / `14.1.0` and the `-pg17` / `-pg16` / `-alpine` variants.

## Changes
- Bump Citus to **14.1.0** across all variants (`ARG VERSION`, apt pin `citus-14.0` → `citus-14.1`): `Dockerfile`, `postgres-17/`, `postgres-16/`, `alpine/Dockerfile`.
- Bump the **PostgreSQL 18 base to 18.4** (`pkgvars` `postgres_18_version`, `FROM postgres:18.4`, `FROM postgres:18.4-alpine`) so the published image matches the 18.4 reported by the apt/yum installs. pg17 (17.6) and pg16 (16.10) bases unchanged.
- Bump the **alpine source-build toolchain to `clang21`/`llvm21`** — the `18.4-alpine` base is Alpine 3.24 (built against LLVM 21); the old `clang19`/`llvm19` packages no longer exist there, and the bitcode step requires `clang-21`.
- `docker-compose.yml` images → `14.1.0`; `CHANGELOG.md` entry.

## Verification (local Docker builds)
| Image | Build | Citus | PostgreSQL |
|-------|-------|-------|-----------|
| latest / PG18 (the `:14.1` tag) | OK | 14.1.0 (ext 14.1-1) | **18.4** |
| alpine (source compile) | OK | 14.1.0 (ext 14.1-1) | **18.4** |
| pg17 | OK (prev. run) | 14.1.0 | 17.6 |

hll `2.19.citus-1` / topn `2.7.0.citus-1` pins unchanged and install fine.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>