### PR TITLE
Pin tools to v0.8.36 to fix Citus docker publish pipeline

### DIFF
--- a/.github/workflows/publish_docker_images_cron.yml
+++ b/.github/workflows/publish_docker_images_cron.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Clone tools branch
-        run: git clone -b v0.8.34 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/publish_docker_images_cron.yml
+++ b/.github/workflows/publish_docker_images_cron.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/publish_docker_images_on_manual.yml
+++ b/.github/workflows/publish_docker_images_on_manual.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/publish_docker_images_on_manual.yml
+++ b/.github/workflows/publish_docker_images_on_manual.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Clone tools branch
-        run: git clone -b v0.8.34 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/publish_docker_images_on_push.yml
+++ b/.github/workflows/publish_docker_images_on_push.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/publish_docker_images_on_push.yml
+++ b/.github/workflows/publish_docker_images_on_push.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Clone tools branch
-        run: git clone -b v0.8.34 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/publish_docker_images_on_tag.yml
+++ b/.github/workflows/publish_docker_images_on_tag.yml
@@ -28,7 +28,7 @@ jobs:
           ref: master
 
       - name: Clone tools branch
-        run: git clone -b v0.8.34 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/publish_docker_images_on_tag.yml
+++ b/.github/workflows/publish_docker_images_on_tag.yml
@@ -28,7 +28,7 @@ jobs:
           ref: master
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources

--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -31,7 +31,7 @@ jobs:
         run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources
 
       - name: Clone tools branch
-        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Set git name and email
         run: |

--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -31,7 +31,7 @@ jobs:
         run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources
 
       - name: Clone tools branch
-        run: git clone -b v0.8.34 --depth=1 https://github.com/citusdata/tools.git tools
+        run: git clone -b v0.8.36-dev5 --depth=1 https://github.com/citusdata/tools.git tools
 
       - name: Set git name and email
         run: |


### PR DESCRIPTION
## Summary
Bumps the pinned `citusdata/tools` clone tag from **`v0.8.34`** to **`v0.8.36-dev5`** in all 5 workflows that clone `tools`. This is a CI pin fix only — no application/image changes.

## Root cause
docker's `pkgvars` no longer defines `postgres_14_version` / `postgres_15_version` (it now provides only `postgres_18/17/16`). tools **v0.8.34** (and v0.8.35) `update_docker.read_postgres_versions()` still indexes `config["postgres_15_version"]` and `config["postgres_14_version"]`, so it raises **`KeyError: 'postgres_15_version'`** against the current `pkgvars`. That breaks **`update_version.yml`** whenever Citus is bumped (e.g. **14.1**).

tools **v0.8.36-dev5** reads only `postgres_18/17/16`, matching `pkgvars` exactly.

### Validation (side-effect-free)
Ran the exact `read_postgres_versions` bodies from both tags against docker's real `pkgvars`:
- `pkgvars` keys present: `postgres_18_version, postgres_17_version, postgres_16_version`
- **v0.8.34 → `KeyError: 'postgres_15_version'`** (root cause reproduced)
- **v0.8.36-dev5 → `('18.1', '17.6', '16.10')`, no error** (fix confirmed)

## Why v0.8.36-dev5 (a pre-release)?
The pg14/15 drop in `update_docker` exists only in tools tags `v0.8.36-dev..dev5`. **Stable `v0.8.36` is not cut yet** (origin/develop still reads pg14/15). `v0.8.36-dev5` is the only existing tag whose `update_docker` matches docker's `pkgvars`.

## ⚠️ Gated — do not merge yet
This PR pins a **pre-release** tag intentionally. **Convergence follow-up:** once stable **`v0.8.36`** is cut (after `citusdata/tools` #409 → #410 merge), update these pins **`v0.8.36-dev5` → `v0.8.36`** and then merge. Lead agent coordinates the tools version cut alongside the GitHub App token migration.

## Scope / safety
- **`publish_docker.py` is byte-identical `v0.8.34..v0.8.36-dev5`** → the 4 publish workflows (`cron`, `on_manual`, `on_push`, `on_tag`) have **no behavior change**; bumped only to keep one coherent pinned version. Only **`update_version.yml`** is functionally fixed.
- **Not touched:** legacy `hyperscale/` (pg-12/13/14) — intentionally left as-is per maintainer decision; Citus version strings (`VERSION=14.0.0`, `citus-14.0`, etc.); `GH_TOKEN` → GitHub App token (separate later phase). No `CHANGELOG` edit.

## Files changed (tag bump only, 1 line each)
| File | Line |
|---|---|
| `.github/workflows/publish_docker_images_cron.yml` | 30 |
| `.github/workflows/publish_docker_images_on_manual.yml` | 29 |
| `.github/workflows/publish_docker_images_on_push.yml` | 28 |
| `.github/workflows/publish_docker_images_on_tag.yml` | 31 |
| `.github/workflows/update_version.yml` | 34 |

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;