### PR TITLE
Docker Phase 4: GH_TOKEN -> GitHub App token (workflows)

### DIFF
--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -27,6 +27,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
+          owner: citusdata
+
+      - name: Export App token to environment
+        run: |
+          echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+          echo "GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Install package dependencies
         run: sudo apt-get update && sudo apt install libcurl4-openssl-dev libssl-dev python3-testresources
 


### PR DESCRIPTION
## Docker Phase 4: org PAT (`GH_TOKEN`) -> GitHub App token

Part of the org-wide CI migration off the org PAT `GH_TOKEN` to a GitHub App token. Docker is the last repo still on the PAT for its write-path workflow.

### What changed
Only **`.github/workflows/update_version.yml`** references the org PAT, so it is the only file changed. Two steps were added after checkout:

1. **Generate GitHub App token** - mints an installation token via `actions/create-github-app-token@v3` (`app-id: vars.GH_APP_ID`, `private-key: secrets.GH_APP_KEY`, `owner: citusdata`).
2. **Export App token to environment** - writes the minted token to `$GITHUB_ENV` as both `GH_TOKEN` and `GITHUB_TOKEN` so downstream steps/scripts consume it.

The existing `--gh_token "${GH_TOKEN}"` argument to `update_docker` is **unchanged** - it now resolves to the app token at runtime. `update_docker --pipeline` does `git push` + opens a PR via `create_pr(gh_token, ...)`; the PR is now created under the GitHub App (so it can trigger downstream workflows and uses the app install contents:write + pull_requests:write). The branch push continues under checkout default `GITHUB_TOKEN` (the workflow already grants `contents: write`), matching the proven sibling pattern.

### Zero-downtime / scope
- **Top-level `GH_TOKEN: secrets.GH_TOKEN` is intentionally retained** (removed only in Phase 6).
- The **4 publish workflows** (`publish_docker_images_*`) use DockerHub creds only - **no change needed**.
- No Citus version strings, no legacy/hyperscale, no tools tag pin touched (the `v0.8.36` pin is a separate convergence PR, #380).
- Mirrors the already-merged pattern in `citusdata/packaging` `update-pgxn-version.yml` (same `update_*` `--gh_token --pipeline` module family).

### Notes
- Base is `master`; diff is purely additive (+13 lines, the two new steps). Independent of #380 - different lines in the same file, no overlap.
- **DRAFT - do not merge.** Gated; opened for review per the migration runbook.

### Push permission (verified)
`update_version.yml` sets an explicit workflow-level `permissions:` block with `contents: write`. An explicit block overrides the repo/org default token permissions, so the default `GITHUB_TOKEN` reliably has `contents: write` for the `git push` step regardless of restrictive defaults. PR creation uses the app token's own `pull_requests:write` (from the install), not the default token — so no `pull-requests` scope is needed in this block.